### PR TITLE
Hide buttons if role doesn't match

### DIFF
--- a/frontend/src/app/welcome/page.tsx
+++ b/frontend/src/app/welcome/page.tsx
@@ -50,12 +50,10 @@ const WelcomePage: React.FC = () => {
       }, 100);
     }
 
-    // When finished typing
     if (!isDeleting && typedGreeting === currentGreeting) {
-      setTimeout(() => setIsDeleting(true), 2000); // pause before deleting
+      setTimeout(() => setIsDeleting(true), 2000);
     }
 
-    // When finished deleting
     if (isDeleting && typedGreeting === '') {
       setIsDeleting(false);
       setGreetingIndex((prev) => (prev + 1) % greetings.length);
@@ -123,39 +121,43 @@ const WelcomePage: React.FC = () => {
         </span>{' '}
         {nameDisplay}, nice to meet you!
       </h1>
-  
+
       {/* Role Buttons */}
       <div className="flex flex-wrap gap-4 mt-4 justify-center">
-        <button
-          className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-200 transition"
-          disabled={!roles.isStudent}
-        >
-          Student
-        </button>
-        <button
-          className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-200 transition"
-          disabled={!roles.isULA && !roles.isAdmin}
-        >
-          Teaching Staff
-        </button>
-        <button
-          className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-200 transition"
-          disabled={!roles.isAdmin}
-          onClick={() => router.push('/instructor')}
-        >
-          Instructor
-        </button>
-        <button
-          onClick={() => router.push('/superuser')}
-          className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-200 transition"
-          disabled={!roles.isSuperuser}
-        >
-          Superuser
-        </button>
+        {roles.isStudent && (
+          <button
+            onClick={() => router.push('/student')}
+            className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold hover:bg-gray-200 transition"
+          >
+            Student
+          </button>
+        )}
+        {(roles.isULA || roles.isAdmin) && (
+          <button
+            className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold hover:bg-gray-200 transition"
+          >
+            Teaching Staff
+          </button>
+        )}
+        {roles.isAdmin && (
+          <button
+            className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold hover:bg-gray-200 transition"
+            onClick={() => router.push('/instructor')}
+          >
+            Instructor
+          </button>
+        )}
+        {roles.isSuperuser && (
+          <button
+            onClick={() => router.push('/superuser')}
+            className="px-6 py-3 rounded-xl bg-white text-[#0e1c2c] font-semibold hover:bg-gray-200 transition"
+          >
+            Superuser
+          </button>
+        )}
       </div>
     </div>
   );
-  
 };
 
 export default WelcomePage;


### PR DESCRIPTION
# Description
- We now hide buttons if roles don't match instead of just disabling them. This way, users can't change permissions based on DevTools to access forbidden pages.

#### Context + Problem:
- We realized route security needs to be better and we can't just have routes that pass in NETID.

#### Solution:
- We now hide buttons if roles don't match instead of just disabling them. This way, users can't change permissions based on DevTools to access forbidden pages.


## Fixes #21 

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Manual testing.

# Reviewers
N/A. Minor change, self-review permitted.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules


# Next Steps:
- Add FE unit tests after functionality built out.